### PR TITLE
Fixed modify/dropfields flow duplication bug. Added more tests.

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -606,8 +606,8 @@ fields parameter. For a list of fields, check our
   config:
     # required, options are drop or keep
     policy: drop
-    # the lines below are optional and set to default
-    fields: ""
+    # required, fields to keep or drop
+    fields: "SrcAddr,DstAddr"
 ```
 
 [godoc](https://pkg.go.dev/github.com/bwNetFlow/flowpipeline/segments/modify/dropfields)

--- a/segments/modify/dropfields/dropfields_test.go
+++ b/segments/modify/dropfields/dropfields_test.go
@@ -1,41 +1,99 @@
 package dropfields
 
 import (
-	"io/ioutil"
-	"log"
-	"os"
-	"sync"
-	"testing"
-
 	"github.com/bwNetFlow/flowpipeline/pb"
 	"github.com/bwNetFlow/flowpipeline/segments"
+	"io"
+	"log"
+	"os"
+	"reflect"
+	"sync"
+	"testing"
 )
 
-// DropFields Segment tests are thorough and try every combination
-func TestSegment_DropFields_policyKeep(t *testing.T) {
-	result := segments.TestSegment("dropfields", map[string]string{"policy": "keep", "fields": "DstAddr"},
-		&pb.EnrichedFlow{SrcAddr: []byte{192, 168, 88, 142}, DstAddr: []byte{192, 168, 88, 143}},
-	)
-	if len(result.SrcAddr) != 0 || len(result.DstAddr) == 0 {
-		t.Error("Segment DropFields is not keeping the proper fields.")
+var (
+	testPacketOne = pb.EnrichedFlow{
+		SrcAddr: []byte{192, 168, 88, 142},
+		DstAddr: []byte{192, 168, 88, 143},
+		SrcPort: 1234,
+		DstPort: 5678,
+		Bytes:   1234567890,
+		Packets: 424242,
 	}
-}
+	testPacketTwo = pb.EnrichedFlow{
+		SrcAddr: []byte{0x2a, 0x00, 0x13, 0x98, 0x00, 0x05, 0x8d, 0x01, 0x00, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x01},
+		DstAddr: []byte{0x2a, 0x00, 0x14, 0x50, 0x40, 0x01, 0x08, 0x2b, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x20, 0x0e},
+		SrcPort: 2323,
+		DstPort: 4242,
+	}
+	tests = map[string]struct {
+		config   map[string]string
+		input    pb.EnrichedFlow
+		expected *pb.EnrichedFlow
+	}{
+		"drop one field": {
+			config: map[string]string{"policy": "drop", "fields": "SrcAddr"},
+			input:  testPacketOne,
+			expected: &pb.EnrichedFlow{
+				DstAddr: []byte{192, 168, 88, 143},
+				SrcPort: 1234,
+				DstPort: 5678,
+				Bytes:   1234567890,
+				Packets: 424242,
+			},
+		},
+		"keep only SrcAddr": {
+			config: map[string]string{"policy": "keep", "fields": "SrcAddr"},
+			input:  testPacketOne,
+			expected: &pb.EnrichedFlow{
+				SrcAddr: []byte{192, 168, 88, 142},
+			},
+		},
+		"keep only DstPort": {
+			config: map[string]string{"policy": "keep", "fields": "DstPort"},
+			input:  testPacketOne,
+			expected: &pb.EnrichedFlow{
+				DstPort: 5678,
+			},
+		},
+		"drop three fields": {
+			config: map[string]string{"policy": "drop", "fields": "SrcAddr, DstAddr, SrcPort "},
+			input:  testPacketOne,
+			expected: &pb.EnrichedFlow{
+				DstPort: 5678,
+				Bytes:   1234567890,
+				Packets: 424242,
+			},
+		},
+		"keep two fields": {
+			config: map[string]string{"policy": "keep", "fields": " SrcAddr , SrcPort"},
+			input:  testPacketTwo,
+			expected: &pb.EnrichedFlow{
+				SrcAddr: []byte{0x2a, 0x00, 0x13, 0x98, 0x00, 0x05, 0x8d, 0x01, 0x00, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x01},
+				SrcPort: 2323,
+			},
+		},
+	}
+)
 
-func TestSegment_DropFields_policyDrop(t *testing.T) {
-	result := segments.TestSegment("dropfields", map[string]string{"policy": "drop", "fields": "SrcAddr"},
-		&pb.EnrichedFlow{SrcAddr: []byte{192, 168, 88, 142}, DstAddr: []byte{192, 168, 88, 143}},
-	)
-	if len(result.SrcAddr) != 0 || len(result.DstAddr) == 0 {
-		t.Error("Segment DropFields is not dropping the proper fields.")
+func TestSegment_DropFields(t *testing.T) {
+	for testname, test := range tests {
+		//t.Logf("Running test case %s", testname)
+		t.Run(testname, func(t *testing.T) {
+			result := segments.TestSegment("dropfields", test.config, &test.input)
+			if !reflect.DeepEqual(result, test.expected) {
+				t.Errorf("Segment DropFields is not returning the proper fields. Got: »%+v« Expected »%+v«", result, test.expected)
+			}
+		})
 	}
 }
 
 // DropFields Segment benchmark passthrough
 func BenchmarkDropFields(b *testing.B) {
-	log.SetOutput(ioutil.Discard)
+	log.SetOutput(io.Discard)
 	os.Stdout, _ = os.Open(os.DevNull)
 
-	segment := DropFields{}.New(map[string]string{"policy": "drop", "fields": "SrcAddr"})
+	segment := DropFields{Policy: PolicyDrop, Fields: []string{"SrcAddr"}}
 
 	in, out := make(chan *pb.EnrichedFlow), make(chan *pb.EnrichedFlow)
 	segment.Rewire(in, out)


### PR DESCRIPTION
Old version of dropfields would only drop/keep a single fields and emit the modified flow causing flow duplication.