### PR TITLE
Parallelize stdin segment unmarshalling

### DIFF
--- a/segments/input/stdin/stdin.go
+++ b/segments/input/stdin/stdin.go
@@ -92,13 +92,15 @@ func (segment *StdIn) Run(wg *sync.WaitGroup) {
 			}
 			segment.Out <- msg
 		case line := <-fromStdin:
-			msg := &pb.EnrichedFlow{}
-			err := protojson.Unmarshal(line, msg)
-			if err != nil {
-				log.Printf("[warning] StdIn: Skipping a flow, failed to recode input to protobuf: %v", err)
-				continue
-			}
-			segment.Out <- msg
+			go func(){
+				msg := &pb.EnrichedFlow{}
+				err := protojson.Unmarshal(line, msg)
+				if err != nil {
+					log.Printf("[warning] StdIn: Skipping a flow, failed to recode input to protobuf: %v", err)
+					return
+				}
+				segment.Out <- msg
+			}()
 		}
 	}
 }


### PR DESCRIPTION
This change speeds up the stdin segment by moving the unmarshalling step of protojson into a goroutine. The protojson implementation is known to be not as optimized as the stdlib json implementation [1]. This change improves performance with more parallelization, leading to the following speedups on an AMD EPYC 7742 dual-socket server:

| nr. of records in JSON | old wall time | new wall time | speedup |
| ---------------------- | ------------- | ------------- | ------- |
|  5473180               | 1m53.214s     | 0m55.954s     | 50%     |
| 16002618               | 5m35.092s     | 2m48.978s     | 50%     |

**This might lead to the reordering of records**, which might also happen on other input segments like goflow. Instead, users should depend on sequence numbers and timestamps in the EnhancedFlow struct.

[1] https://github.com/golang/protobuf/issues/1285