### PR TITLE
feat(main): Add possibility to concurrently spawn pipelines using -j

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 config.yml
-config
+/config/
 *.so
 
 .idea

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -25,23 +25,32 @@ flowpipeline was invoked with that have not been parsed by the binary itself.
 For instance:
 
 ```yaml
-segment: kafkaconsumer
-config:
-  user: myself
-  pass: $PASSWORD
+- segment: kafkaconsumer
+  config:
+    user: myself
+    pass: $PASSWORD
 ```
 
 ```yaml
-segment: flowfilter
-config:
-  filter: $0
+- segment: flowfilter
+  config:
+    filter: $0
 ```
 
 ```yaml
-segment: bpf
-config:
-  device: $0
+- segment: bpf
+  config:
+    device: $0
 ```
+
+## Parallel execution
+```yaml
+- segment: segment_name
+  jobs: 5
+```
+The `jobs` parameter allows you to configure the number of parallel instances of a segment that should be run. The application will create the specified number of parallel instances of the segment and distribute the workload across them. This can significantly reduce the overall processing time, especially for large or complex segments.
+If not set, the default value is 1.
+Note that using too many parallel instances can also lead to performance degradation, as the overhead of managing the parallel processes may outweigh the benefits. 
 
 ## Available Segments
 
@@ -126,7 +135,7 @@ allow for a more efficient filtering.
 
 Filters with a specified `traffictyp` will be exported if they reach the configured thresholds.
 
-```
+```yaml
 - segment: traffic_specific_toptalkers
   config:
     endpoint: ":8085"
@@ -480,12 +489,12 @@ The filter parameter available for some methods will filter packets before they 
 ```yaml
 - segment: packet
   config:
-	method: pcap # required, one of the available capture methods "pcapgo|pcap|pfring|file"
-	source:      # required, for example "eth0" or "./dump.pcapng"
-  # the lines below are optional and set to default
-	filter: "" # optional pflang filter (libpcap's high-level BPF syntax), provided the method is libpcap, pfring, or file.
-	activetimeout: 30m
-	inactivetimeout: 15s
+    method: pcap # required, one of the available capture methods "pcapgo|pcap|pfring|file"
+    source:      # required, for example "eth0" or "./dump.pcapng"
+    # the lines below are optional and set to default
+    filter: "" # optional pflang filter (libpcap's high-level BPF syntax), provided the method is libpcap, pfring, or file.
+    activetimeout: 30m
+    inactivetimeout: 15s
 ```
 
 [godoc](https://pkg.go.dev/github.com/BelWue/flowpipeline/segments/packet/bpf)
@@ -1084,7 +1093,7 @@ To see debug output, set the `-l debug` flag when starting `flowpipeline`.
 See [time.ParseDuration](https://pkg.go.dev/time#ParseDuration) for proper duration format
 strings and [strconv.ParseBool](https://pkg.go.dev/strconv#ParseBool) for allowed bool keywords.
 
-```
+```yaml
 - segment: lumberjack
   config:
     servers: tcp://foo.example.com:5044, tls://bar.example.com:5044?compression=3, tlsnoverify://[2001:db8::1]:5044
@@ -1172,7 +1181,6 @@ for an application.
     useprotoname: true
     verbose: false
     highlight: false
-
 ```
 [godoc](https://pkg.go.dev/github.com/BelWue/flowpipeline/segments/print/printflowdump)
 [examples using this segment](https://github.com/search?q=%22segment%3A+printflowdump%22+extension%3Ayml+repo%3AbwNetFlow%2Fflowpipeline%2Fexamples&type=Code)

--- a/main.go
+++ b/main.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/signal"
 	"plugin"
+	"runtime"
 	"strings"
 	"syscall"
 	"time"
@@ -88,8 +89,9 @@ func (i *flagArray) Set(value string) error {
 
 func main() {
 	var pluginPaths flagArray
-	flag.Var(&pluginPaths, "p", "path to load segment plugins from, can be specified multiple times")
-	logLevel := flag.String("l", "info", "loglevel: one of 'trace', 'debug', 'info', 'warning', 'error', 'fatal', or 'panic'")
+	flag.Var(&pluginPaths, "p", "Path to load segment plugins from, can be specified multiple times")
+	logLevel := flag.String("l", "warning", "Loglevel: one of 'debug', 'info', 'warning' or 'error'")
+	concurrency := flag.Uint("n", 1, "Number of concurrent pipelines to spawn. Set to 0 to enable automatic setting according to GOMAXPROCS. Only the default value 1 guarantees a stable order of the flows in and out of flowpipeline.")
 	version := flag.Bool("v", false, "print version")
 	prettyLogging := flag.Bool("j", false, "Json log")
 	configFile := flag.String("c", "config.yml", "location of the config file in yml format")
@@ -125,9 +127,22 @@ func main() {
 		log.Error().Err(err).Msg(" reading config file: ")
 		return
 	}
-	pipe := pipeline.NewFromConfig(config)
-	pipe.Start()
-	pipe.AutoDrain()
+
+	pipelineCount := 1
+	if *concurrency == 0 {
+		pipelineCount = runtime.GOMAXPROCS(0)
+	} else {
+		pipelineCount = int(*concurrency)
+	}
+
+	segmentReprs := pipeline.SegmentReprsFromConfig(config)
+	for i := 0; i < pipelineCount; i++ {
+		segments := pipeline.SegmentsFromRepr(segmentReprs)
+		pipe := pipeline.New(segments...)
+		pipe.Start()
+		pipe.AutoDrain()
+		defer pipe.Close()
+	}
 
 	sigs := make(chan os.Signal, 1)
 	signal.Notify(sigs, os.Interrupt, syscall.SIGINT)
@@ -139,7 +154,6 @@ func main() {
 		log.Fatal().Msg("Failed to shut down gracefully - force quitting")
 		os.Exit(5)
 	}()
-	pipe.Close()
 }
 
 func zerologLogLevel(logLevel *string) zerolog.Level {

--- a/pipeline/config.go
+++ b/pipeline/config.go
@@ -84,20 +84,21 @@ func SegmentReprsFromConfig(config []byte) []SegmentRepr {
 
 // Creates a list of Segments from their config representations. Handles
 // recursive definitions found in Segments.
-func SegmentsFromRepr(segmentReprs []SegmentRepr) []segments.SegmentWrapper {
-	segmentList := make([]segments.SegmentWrapper, len(segmentReprs))
+func SegmentsFromRepr(segmentReprs []SegmentRepr) []segments.ParallelizedSegment {
+	segmentList := make([]segments.ParallelizedSegment, len(segmentReprs))
 	for i, segmentrepr := range segmentReprs {
 		if segmentrepr.Jobs < 1 {
 			segmentrepr.Jobs = 1
 		}
-		wrapper := segments.SegmentWrapper{}
+		wrapper := segments.ParallelizedSegment{}
 
 		ifPipeline := New(SegmentsFromRepr(segmentrepr.If)...)
 		thenPipeline := New(SegmentsFromRepr(segmentrepr.Then)...)
 		elsePipeline := New(SegmentsFromRepr(segmentrepr.Else)...)
 
+		segmentTemplate := segments.LookupSegment(segmentrepr.Name) // a typed nil instance
+
 		for range segmentrepr.Jobs {
-			segmentTemplate := segments.LookupSegment(segmentrepr.Name) // a typed nil instance
 			// the Segment's New method knows how to handle our config
 			segment := segmentTemplate.New(segmentrepr.ExpandedConfig())
 			switch segment := segment.(type) { // handle special segments

--- a/pipeline/config.go
+++ b/pipeline/config.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/rs/zerolog/log"
 
+	"github.com/BelWue/flowpipeline/pipeline/config"
 	"github.com/BelWue/flowpipeline/segments"
-	"github.com/BelWue/flowpipeline/segments/analysis/traffic_specific_toptalkers"
 	"github.com/BelWue/flowpipeline/segments/controlflow/branch"
 	"gopkg.in/yaml.v2"
 )
@@ -16,22 +16,11 @@ import (
 // A config representation of a segment.
 type SegmentRepr struct {
 	Name   string        `yaml:"segment"`             // to be looked up with a registry
-	Config Config        `yaml:"config"`              // to be expanded by our instance
+	Config config.Config `yaml:"config"`              // to be expanded by our instance
 	Jobs   int           `yaml:"jobs,omitempty"`      // parallel jobs running the pipeline
 	If     []SegmentRepr `yaml:"if,omitempty,flow"`   // only used by group segment
 	Then   []SegmentRepr `yaml:"then,omitempty,flow"` // only used by group segment
 	Else   []SegmentRepr `yaml:"else,omitempty,flow"` // only used by group segment
-}
-
-// Allows adding Config params that arnt only a simple map
-// Needs to be expanded by every Segment using it
-type Config struct {
-	Config map[string]string `yaml:",inline"`
-
-	//Define custom segment specific structured config params here
-	//The parameter MUST contain the segement name to not conflict with other existing config parameters
-	//Make sure to also add mapping of the custom config in the SegmentsFromRepr function
-	ThresholdMetricDefinition []*traffic_specific_toptalkers.ThresholdMetricDefinition `yaml:"traffic_specific_toptalkers,omitempty"`
 }
 
 // Returns the SegmentRepr's Config with all its variables expanded. It tries
@@ -122,8 +111,7 @@ func segmentFromTemplate(ifPipeline, thenPipeline, elsePipeline *Pipeline, segme
 			thenPipeline,
 			elsePipeline,
 		)
-	case *traffic_specific_toptalkers.TrafficSpecificToptalkers:
-		segment.SetThresholdMetricDefinition(segmentrepr.Config.ThresholdMetricDefinition)
 	}
+	segment.AddCustomConfig(segmentrepr.Config)
 	return segment
 }

--- a/pipeline/config/config.go
+++ b/pipeline/config/config.go
@@ -1,0 +1,11 @@
+package config
+
+// Allows adding Config params that arnt only a simple map
+// Needs to be expanded by every Segment using it
+type Config struct {
+	Config map[string]string `yaml:",inline"`
+
+	//Define custom segment specific structured config params here
+	//The parameter MUST contain the segement name to not conflict with other existing config parameters
+	ThresholdMetricDefinition []*ThresholdMetricDefinition `yaml:"traffic_specific_toptalkers,omitempty"`
+}

--- a/pipeline/config/toptalker_config.go
+++ b/pipeline/config/toptalker_config.go
@@ -1,0 +1,18 @@
+package config
+
+type ThresholdMetricDefinition struct {
+	PrometheusMetricsParamsDefinition `yaml:",inline"`
+	FilterDefinition                  string                       `yaml:"filter,omitempty"`
+	SubDefinitions                    []*ThresholdMetricDefinition `yaml:"subfilter,omitempty"`
+}
+
+type PrometheusMetricsParamsDefinition struct {
+	TrafficType      string `yaml:"traffictype,omitempty"`      // optional, default is "", name for the traffic type (included as label)
+	Buckets          int    `yaml:"buckets,omitempty"`          // optional, default is 60, sets the number of seconds used as a sliding window size
+	ThresholdBuckets int    `yaml:"thresholdbuckets,omitempty"` // optional, use the last N buckets for calculation of averages, default: $Buckets
+	ReportBuckets    int    `yaml:"reportbuckets,omitempty"`    // optional, use the last N buckets to calculate averages that are reported as result, default: $Buckets
+	BucketDuration   int    `yaml:"bucketduration,omitempty"`   // optional, duration of a bucket, default is 1 second
+	ThresholdBps     uint64 `yaml:"thresholdbps,omitempty"`     // optional, default is 0, only log talkers with an average bits per second rate higher than this value
+	ThresholdPps     uint64 `yaml:"thresholdpps,omitempty"`     // optional, default is 0, only log talkers with an average packets per second rate higher than this value
+	RelevantAddress  string `yaml:"relevantaddress,omitempty"`  // optional, default is "destination", options are "destination", "source", "both"
+}

--- a/pipeline/pipeline.go
+++ b/pipeline/pipeline.go
@@ -19,7 +19,7 @@ type Pipeline struct {
 	Out         <-chan *pb.EnrichedFlow
 	Drop        chan *pb.EnrichedFlow
 	wg          *sync.WaitGroup
-	SegmentList []segments.SegmentWrapper
+	SegmentList []segments.ParallelizedSegment
 }
 
 func (pipeline *Pipeline) GetInput() chan *pb.EnrichedFlow {
@@ -75,11 +75,11 @@ func (pipeline *Pipeline) Close() {
 // Initializes a new Pipeline object and then starts all segment goroutines
 // therein. Initialization includes creating any intermediate channels and
 // wiring up the segments in the segmentList with them.
-func New(segmentList ...segments.SegmentWrapper) *Pipeline {
+func New(segmentList ...segments.ParallelizedSegment) *Pipeline {
 	if len(segmentList) == 0 {
-		wrapper := segments.SegmentWrapper{}
+		wrapper := segments.ParallelizedSegment{}
 		wrapper.AddSegment(&pass.Pass{})
-		segmentList = []segments.SegmentWrapper{wrapper}
+		segmentList = []segments.ParallelizedSegment{wrapper}
 	}
 	channels := make([]chan *pb.EnrichedFlow, len(segmentList)+1)
 	channels[0] = make(chan *pb.EnrichedFlow)

--- a/pipeline/pipeline_test.go
+++ b/pipeline/pipeline_test.go
@@ -14,7 +14,10 @@ import (
 )
 
 func TestPipelineBuild(t *testing.T) {
-	segmentList := []segments.Segment{&pass.Pass{}, &pass.Pass{}}
+	segmentList := []segments.SegmentWrapper{{}, {}}
+	segmentList[0].AddSegment(&pass.Pass{})
+	segmentList[1].AddSegment(&pass.Pass{})
+
 	pipeline := New(segmentList...)
 	pipeline.Start()
 	pipeline.In <- &pb.EnrichedFlow{Type: 3}
@@ -25,7 +28,9 @@ func TestPipelineBuild(t *testing.T) {
 }
 
 func TestPipelineTeardown(t *testing.T) {
-	segmentList := []segments.Segment{&pass.Pass{}, &pass.Pass{}}
+	segmentList := []segments.SegmentWrapper{{}, {}}
+	segmentList[0].AddSegment(&pass.Pass{})
+	segmentList[1].AddSegment(&pass.Pass{})
 	pipeline := New(segmentList...)
 	pipeline.Start()
 	pipeline.AutoDrain()

--- a/pipeline/pipeline_test.go
+++ b/pipeline/pipeline_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestPipelineBuild(t *testing.T) {
-	segmentList := []segments.SegmentWrapper{{}, {}}
+	segmentList := []segments.ParallelizedSegment{{}, {}}
 	segmentList[0].AddSegment(&pass.Pass{})
 	segmentList[1].AddSegment(&pass.Pass{})
 
@@ -28,7 +28,7 @@ func TestPipelineBuild(t *testing.T) {
 }
 
 func TestPipelineTeardown(t *testing.T) {
-	segmentList := []segments.SegmentWrapper{{}, {}}
+	segmentList := []segments.ParallelizedSegment{{}, {}}
 	segmentList[0].AddSegment(&pass.Pass{})
 	segmentList[1].AddSegment(&pass.Pass{})
 	pipeline := New(segmentList...)

--- a/pipeline/pipeline_test.go
+++ b/pipeline/pipeline_test.go
@@ -14,9 +14,10 @@ import (
 )
 
 func TestPipelineBuild(t *testing.T) {
-	segmentList := []segments.ParallelizedSegment{{}, {}}
-	segmentList[0].AddSegment(&pass.Pass{})
-	segmentList[1].AddSegment(&pass.Pass{})
+	segmentList := []segments.Segment{&pass.Pass{}, &segments.ParallelizedSegment{}}
+
+	parallelizedSegment, _ := (segmentList[1]).(*segments.ParallelizedSegment)
+	parallelizedSegment.AddSegment(&pass.Pass{})
 
 	pipeline := New(segmentList...)
 	pipeline.Start()
@@ -28,9 +29,11 @@ func TestPipelineBuild(t *testing.T) {
 }
 
 func TestPipelineTeardown(t *testing.T) {
-	segmentList := []segments.ParallelizedSegment{{}, {}}
-	segmentList[0].AddSegment(&pass.Pass{})
-	segmentList[1].AddSegment(&pass.Pass{})
+	segmentList := []segments.Segment{&pass.Pass{}, &segments.ParallelizedSegment{}}
+
+	parallelizedSegment, _ := (segmentList[1]).(*segments.ParallelizedSegment)
+	parallelizedSegment.AddSegment(&pass.Pass{})
+
 	pipeline := New(segmentList...)
 	pipeline.Start()
 	pipeline.AutoDrain()

--- a/segments/analysis/toptalkers_metrics/toptalker_prometheus.go
+++ b/segments/analysis/toptalkers_metrics/toptalker_prometheus.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strconv"
 
+	"github.com/BelWue/flowpipeline/pipeline/config"
 	"github.com/rs/zerolog/log"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -18,22 +19,15 @@ type PrometheusCollector struct {
 	trafficPpsDesc *prometheus.Desc
 }
 
-type PrometheusMetricsParams struct {
-	TrafficType        string `yaml:"traffictype,omitempty"`      // optional, default is "", name for the traffic type (included as label)
-	Buckets            int    `yaml:"buckets,omitempty"`          // optional, default is 60, sets the number of seconds used as a sliding window size
-	ThresholdBuckets   int    `yaml:"thresholdbuckets,omitempty"` // optional, use the last N buckets for calculation of averages, default: $Buckets
-	ReportBuckets      int    `yaml:"reportbuckets,omitempty"`    // optional, use the last N buckets to calculate averages that are reported as result, default: $Buckets
-	BucketDuration     int    `yaml:"bucketduration,omitempty"`   // optional, duration of a bucket, default is 1 second
-	ThresholdBps       uint64 `yaml:"thresholdbps,omitempty"`     // optional, default is 0, only log talkers with an average bits per second rate higher than this value
-	ThresholdPps       uint64 `yaml:"thresholdpps,omitempty"`     // optional, default is 0, only log talkers with an average packets per second rate higher than this value
-	RelevantAddress    string `yaml:"relevantaddress,omitempty"`  // optional, default is "destination", options are "destination", "source", "both"
-	CleanupWindowSizes int
-}
-
 type PrometheusParams struct {
 	Endpoint     string // optional, default value is ":8080"
 	MetricsPath  string // optional, default is "/metrics"
 	FlowdataPath string // optional, default is "/flowdata"
+}
+
+type PrometheusMetricsParams struct {
+	config.PrometheusMetricsParamsDefinition
+	CleanupWindowSizes int
 }
 
 func NewPrometheusCollector(databases []*Database) *PrometheusCollector {

--- a/segments/analysis/toptalkers_metrics/toptalkers_metrics.go
+++ b/segments/analysis/toptalkers_metrics/toptalkers_metrics.go
@@ -62,11 +62,12 @@ func (segment *ToptalkersMetrics) Run(wg *sync.WaitGroup) {
 	for msg := range segment.In {
 		promExporter.KafkaMessageCount.Inc()
 		var keys []string
-		if segment.RelevantAddress == "source" {
+		switch segment.RelevantAddress {
+		case "source":
 			keys = []string{msg.SrcAddrObj().String()}
-		} else if segment.RelevantAddress == "destination" {
+		case "destination":
 			keys = []string{msg.DstAddrObj().String()}
-		} else if segment.RelevantAddress == "both" {
+		case "both":
 			keys = []string{msg.SrcAddrObj().String(), msg.DstAddrObj().String()}
 		}
 		forward := false

--- a/segments/analysis/traffic_specific_toptalkers/traffic-specific-toptalkers_test.go
+++ b/segments/analysis/traffic_specific_toptalkers/traffic-specific-toptalkers_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/rs/zerolog/log"
 
 	"github.com/BelWue/flowpipeline/pb"
+	"github.com/BelWue/flowpipeline/pipeline/config"
 	"github.com/BelWue/flowpipeline/segments"
-	"github.com/BelWue/flowpipeline/segments/analysis/toptalkers_metrics"
 )
 
 func TestSegment_Branch_passthrough(t *testing.T) {
@@ -17,20 +17,22 @@ func TestSegment_Branch_passthrough(t *testing.T) {
 
 	segment := segments.LookupSegment("traffic_specific_toptalkers")
 	//normally done via config
-	segment.(*TrafficSpecificToptalkers).ThresholdMetricDefinition = []*ThresholdMetricDefinition{
-		{
-			FilterDefinition: "proto udp",
-			SubDefinitions: []*ThresholdMetricDefinition{
-				{
-					FilterDefinition: "port 123",
-					PrometheusMetricsParams: toptalkers_metrics.PrometheusMetricsParams{
-						TrafficType:  "NTP",
-						ThresholdBps: 1,
+	segment.AddCustomConfig(config.Config{
+		ThresholdMetricDefinition: []*config.ThresholdMetricDefinition{
+			{
+				FilterDefinition: "proto udp",
+				SubDefinitions: []*config.ThresholdMetricDefinition{
+					{
+						FilterDefinition: "port 123",
+						PrometheusMetricsParamsDefinition: config.PrometheusMetricsParamsDefinition{
+							TrafficType:  "NTP",
+							ThresholdBps: 1,
+						},
 					},
 				},
 			},
 		},
-	}
+	})
 
 	segment = segment.New(map[string]string{})
 

--- a/segments/filter/elephant/elephant.go
+++ b/segments/filter/elephant/elephant.go
@@ -8,9 +8,9 @@ import (
 	"sync"
 	"time"
 
+	"github.com/BelWue/flowpipeline/segments"
 	"github.com/rs/zerolog/log"
 
-	"github.com/BelWue/flowpipeline/segments"
 	"github.com/asecurityteam/rolling"
 )
 

--- a/segments/filter_segment.go
+++ b/segments/filter_segment.go
@@ -1,0 +1,35 @@
+// This package is home to all pipeline segment implementations. Generally,
+// every segment lives in its own package, implements the Segment interface,
+// embeds the BaseSegment to take care of the I/O side of things, and has an
+// additional init() function to register itself using RegisterSegment.
+package segments
+
+import (
+	"github.com/BelWue/flowpipeline/pb"
+)
+
+type FilterSegment interface {
+	Segment
+	SubscribeDrops(drops chan<- *pb.EnrichedFlow) //for processing dropped packages
+}
+
+// An extended basis for Segment implementations in the filter group. It
+// contains the necessities to process filtered (dropped) flows.
+type BaseFilterSegment struct {
+	BaseSegment
+	Drops chan<- *pb.EnrichedFlow
+}
+
+// Set a return channel for dropped flow messages. Segments need to be wary of
+// this channel closing when producing messages to this channel. This method is
+// only called by the flowpipeline tool from the controlflow/branch segment to
+// implement the then/else branches, otherwise this functionality is unused.
+func (segment *BaseFilterSegment) SubscribeDrops(drops chan<- *pb.EnrichedFlow) {
+	segment.Drops = drops
+}
+
+// Close implements Segment.
+// Subtle: this method shadows the method (BaseSegment).Close of BaseFilterSegment.BaseSegment.
+func (segment *BaseFilterSegment) Close() {
+	segment.BaseSegment.Close()
+}

--- a/segments/filter_segment.go
+++ b/segments/filter_segment.go
@@ -27,9 +27,3 @@ type BaseFilterSegment struct {
 func (segment *BaseFilterSegment) SubscribeDrops(drops chan<- *pb.EnrichedFlow) {
 	segment.Drops = drops
 }
-
-// Close implements Segment.
-// Subtle: this method shadows the method (BaseSegment).Close of BaseFilterSegment.BaseSegment.
-func (segment *BaseFilterSegment) Close() {
-	segment.BaseSegment.Close()
-}

--- a/segments/parallelized_segment.go
+++ b/segments/parallelized_segment.go
@@ -1,0 +1,64 @@
+// This package is home to all pipeline segment implementations. Generally,
+// every segment lives in its own package, implements the Segment interface,
+// embeds the BaseSegment to take care of the I/O side of things, and has an
+// additional init() function to register itself using RegisterSegment.
+package segments
+
+import (
+	"sync"
+
+	"github.com/BelWue/flowpipeline/pb"
+)
+
+// Wrapper allowing multiple parallel instances of a segment by wiring in/out/drops-channels to all contained segments
+type ParallelizedSegment struct {
+	BaseFilterSegment
+	segments []Segment
+}
+
+func (segment *ParallelizedSegment) New(config map[string]string) Segment {
+	// This method should never be called, since ParallelizedSegment is just a wrapper for other segmets
+	panic("ParallelizedSegment should not be instantiated using New()")
+}
+
+func (segment *ParallelizedSegment) Close() {
+	for _, segment := range segment.segments {
+		segment.Close()
+	}
+}
+
+func (segment *ParallelizedSegment) SubscribeDrops(drop chan *pb.EnrichedFlow) {
+	for _, nestedSegment := range segment.segments {
+		filterSegment, ok := nestedSegment.(FilterSegment)
+		if ok {
+			filterSegment.SubscribeDrops(drop)
+		}
+	}
+}
+
+func (segment *ParallelizedSegment) Run(wg *sync.WaitGroup) {
+	defer wg.Done()
+	segmentWg := sync.WaitGroup{}
+	for _, segment := range segment.segments {
+		segmentWg.Add(1)
+		go segment.Run(&segmentWg)
+	}
+	segmentWg.Wait()
+}
+
+func (segment *ParallelizedSegment) Rewire(in chan *pb.EnrichedFlow, out chan *pb.EnrichedFlow) {
+	for _, segment := range segment.segments {
+		segment.Rewire(in, out)
+	}
+}
+
+func (segment *ParallelizedSegment) AddSegment(nestedSegment Segment) {
+	segment.segments = append(segment.segments, nestedSegment)
+}
+
+// ShutdownParentPipeline implements Segment.
+func (segment *ParallelizedSegment) ShutdownParentPipeline() {
+	for _, segment := range segment.segments {
+		segment.ShutdownParentPipeline()
+	}
+}

--- a/segments/segments.go
+++ b/segments/segments.go
@@ -9,6 +9,7 @@ import (
 	"syscall"
 
 	"github.com/BelWue/flowpipeline/pb"
+	"github.com/BelWue/flowpipeline/pipeline/config"
 	"github.com/rs/zerolog/log"
 )
 
@@ -72,6 +73,7 @@ type Segment interface {
 	Run(wg *sync.WaitGroup)                                     // goroutine, must close(segment.Out) when segment.In is closed
 	Rewire(in chan *pb.EnrichedFlow, out chan *pb.EnrichedFlow) // embed this using BaseSegment
 	ShutdownParentPipeline()                                    // shut down Parent Pipeline gracefully
+	AddCustomConfig(config config.Config)                       //Add segment specific sturctured config parameters
 	Close()
 }
 
@@ -102,4 +104,8 @@ func (segment *BaseSegment) ShutdownParentPipeline() {
 
 func (segment *BaseSegment) Close() {
 	//placeholder since most segments dont need to do anything
+}
+
+func (segment *BaseSegment) AddCustomConfig(config.Config) {
+	//placeholder since most segments dont have a custom sturctured config
 }


### PR DESCRIPTION
Just a first draft. Effectively, this spawns `j` concurrent pipelines that are wired up separately. Hence, it might affect the order of throughput. We could leverage concurrency even better my wiring up the pipeline in a non-static way, i.e. for every segment boundary we have just one channel, with `j` segments writing and reading to each of these boundary channels. 

That'll be more complex, but I'm not sure it is worth the complexity in terms of gain.