### PR TITLE
Fixed deprecated build artifacts

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -36,7 +36,7 @@ jobs:
       run: go build -o flowpipeline -ldflags "-X main.Version=${{ github.sha }}" .
 
     - name: save binary
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4.6.0
       with:
         name: flowpipeline-${{ matrix.goos }}
         path: ./flowpipeline
@@ -47,7 +47,7 @@ jobs:
         CGO_ENABLED: 0
 
     - name: save statically linked binary
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4.6.0
       with:
         name: flowpipeline-${{ matrix.goos }}-static
         path: ./flowpipeline-static


### PR DESCRIPTION
actions/upload-artifact@v3 is deprecated and leads to a build failure.