### PR TITLE
New segment traffic specific toptalkers

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -74,7 +74,7 @@ conditional, limiting payload data, and multiple receivers.
 Segments in this group do higher level analysis on flow data. They usually
 export or print results in some way, but might also filter given flows.
 
-#### toptalkers-metrics
+#### toptalkers_metrics
 The `toptalkers-metrics` segment calculates statistics about traffic levels
 per IP address and exports them in OpenMetrics format via HTTP.
 
@@ -100,7 +100,7 @@ The parameter "traffictype" is passed as OpenMetrics label, so this segment
 can be used multiple times in one pipeline without metrics getting mixed up.
 
 ```yaml
-- segment: toptalkers-metrics
+- segment: toptalkers_metrics
   config:
     # the lines below are optional and set to default
     traffictype: ""
@@ -118,6 +118,38 @@ can be used multiple times in one pipeline without metrics getting mixed up.
 
 [godoc](https://pkg.go.dev/github.com/BelWue/flowpipeline/segments/analysis/toptalkers-metrics)
 [examples using this segment](https://github.com/search?q=%22segment%3A+toptalkers-metrics%22+extension%3Ayml+repo%3AbwNetFlow%2Fflowpipeline%2Fexamples&type=Code)
+
+#### traffic_specific_toptalkers
+The traffic specific toptalker metrics segement is simmilar to the `toptalker-metrics` segment, 
+but allows filtering for specific protocols. The use of nested filters is supported to
+allow for a more efficient filtering.
+
+Filters with a specified `traffictyp` will be exported if they reach the configured thresholds.
+
+```
+- segment: traffic_specific_toptalkers
+  config:
+    endpoint: ":8085"
+  definitions:
+  - filter: "proto udp"
+    metricdefinitions:
+    - filter: "port 0"
+      traffictype: "UDP Fragmented"
+      thresholdbps: 100
+    - filter: "port 53"
+      traffictype: "DNS"
+      filter: "port 53"
+      thresholdbps: 100
+    - filter: "port 123"
+      traffictype: "NTP"
+      thresholdbps: 100
+    - filter: "port 389"
+      traffictype: "CLDAP"
+      thresholdbps: 100
+  - filter: "proto icmp or proto icmpv6"
+    traffictype: "ICMP"
+    thresholdpps: 100
+```
 
 ### Controlflow Group
 Segments in this group have the ability to change the sequence of segments any

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/BelWue/flowpipeline
 
 go 1.23.2
 
-replace github.com/BelWue/flowpipeline => github.com/BelWue/flowpipeline v1.3.1-0.20250127122013-c865e669d527
+replace github.com/BelWue/flowpipeline => .
 
 require (
 	github.com/BelWue/bgp_routeinfo v0.0.0-20221004100427-d8095fc566dd

--- a/pipeline/config.go
+++ b/pipeline/config.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 
 	"github.com/BelWue/flowpipeline/segments"
+	"github.com/BelWue/flowpipeline/segments/analysis/traffic_specific_toptalkers"
 	"github.com/BelWue/flowpipeline/segments/controlflow/branch"
 	"gopkg.in/yaml.v2"
 )
@@ -19,11 +20,12 @@ import (
 //
 // This struct has the appropriate yaml tags inline.
 type SegmentRepr struct {
-	Name   string            `yaml:"segment"`             // to be looked up with a registry
-	Config map[string]string `yaml:"config"`              // to be expanded by our instance
-	If     []SegmentRepr     `yaml:"if,omitempty,flow"`   // only used by group segment
-	Then   []SegmentRepr     `yaml:"then,omitempty,flow"` // only used by group segment
-	Else   []SegmentRepr     `yaml:"else,omitempty,flow"` // only used by group segment
+	Name       string                                                   `yaml:"segment"`               // to be looked up with a registry
+	Config     map[string]string                                        `yaml:"config"`                // to be expanded by our instance
+	If         []SegmentRepr                                            `yaml:"if,omitempty,flow"`     // only used by group segment
+	Then       []SegmentRepr                                            `yaml:"then,omitempty,flow"`   // only used by group segment
+	Else       []SegmentRepr                                            `yaml:"else,omitempty,flow"`   // only used by group segment
+	Definition []*traffic_specific_toptalkers.ThresholdMetricDefinition `yaml:"definitions,omitempty"` // used to add addition data that is parsed by the segment - e.g. for configs that use complex data
 }
 
 // Returns the SegmentRepr's Config with all its variables expanded. It tries
@@ -80,6 +82,8 @@ func SegmentsFromRepr(segmentReprs *[]SegmentRepr) []segments.Segment {
 				New(SegmentsFromRepr(&segmentrepr.Then)...),
 				New(SegmentsFromRepr(&segmentrepr.Else)...),
 			)
+		case *traffic_specific_toptalkers.TrafficSpecificToptalkers:
+			segment.SetThresholdMetricDefinition(segmentrepr.Definition)
 		}
 		if segment != nil {
 			segmentList[i] = segment

--- a/segments/analysis/toptalkers_metrics/toptalker_database.go
+++ b/segments/analysis/toptalkers_metrics/toptalker_database.go
@@ -1,0 +1,232 @@
+package toptalkers_metrics
+
+import (
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+type Record struct {
+	FwdBytes       []uint64
+	FwdPackets     []uint64
+	DropBytes      []uint64
+	DropPackets    []uint64
+	capacity       int
+	pointer        int
+	aboveThreshold atomic.Bool
+	sync.RWMutex
+}
+
+type Database struct {
+	database         *map[string]*Record
+	thresholdBps     uint64
+	thresholdPps     uint64
+	buckets          int // seconds
+	bucketDuration   int // seconds
+	thresholdBuckets int
+	cleanupCounter   int
+	promExporter     *PrometheusExporter
+	stopCleanupC     chan struct{}
+	stopClockC       chan struct{}
+	sync.RWMutex
+}
+
+func NewDatabase(thresholdBps uint64, thresholdPps uint64, buckets int, bucketDuration int, thresholdBuckets int, cleanupWindowSizes int, promExporter *PrometheusExporter) Database {
+	return Database{
+		database:         &map[string]*Record{},
+		thresholdBps:     thresholdBps,
+		thresholdPps:     thresholdPps,
+		thresholdBuckets: thresholdBuckets,
+		cleanupCounter:   buckets * cleanupWindowSizes, // cleanup every N windows
+		promExporter:     promExporter,
+		buckets:          buckets,
+		bucketDuration:   bucketDuration,
+		stopCleanupC:     make(chan struct{}),
+		stopClockC:       make(chan struct{}),
+	}
+}
+
+func (db *Database) GetRecord(key string) *Record {
+	db.Lock()
+	defer db.Unlock()
+	record, found := (*db.database)[key]
+	if !found || record == nil {
+		record = NewRecord(db.buckets)
+		(*db.database)[key] = record
+	}
+	return record
+}
+
+func NewRecord(windowSize int) *Record {
+	record := &Record{
+		FwdBytes:    make([]uint64, windowSize),
+		FwdPackets:  make([]uint64, windowSize),
+		DropBytes:   make([]uint64, windowSize),
+		DropPackets: make([]uint64, windowSize),
+		capacity:    windowSize,
+		pointer:     0,
+	}
+	return record
+}
+
+func (record *Record) Append(bytes uint64, packets uint64, statusFwd bool) {
+	record.Lock()
+	defer record.Unlock()
+	if statusFwd {
+		record.FwdBytes[record.pointer] += bytes
+		record.FwdPackets[record.pointer] += packets
+	} else {
+		record.DropBytes[record.pointer] += bytes
+		record.DropPackets[record.pointer] += packets
+	}
+}
+
+func (record *Record) isEmpty() bool {
+	record.RLock()
+	defer record.RUnlock()
+	for i := 0; i < record.capacity; i++ {
+		if record.FwdPackets[i] > 0 || record.DropPackets[i] > 0 {
+			return false
+		}
+	}
+	return true
+}
+
+func (record *Record) GetMetrics(buckets int, bucketDuration int) (float64, float64, float64, float64) {
+	// buckets == 0 means "look at the whole window"
+	if buckets == 0 {
+		buckets = record.capacity
+	}
+	sumFwdBytes := uint64(0)
+	sumFwdPackets := uint64(0)
+	sumDropBytes := uint64(0)
+	sumDropPackets := uint64(0)
+	record.RLock()
+	defer record.RUnlock()
+	pos := record.pointer
+	for i := 0; i < buckets; i++ {
+		if pos <= 0 {
+			pos = record.capacity - 1
+		} else {
+			pos--
+		}
+		sumFwdBytes += record.FwdBytes[pos]
+		sumFwdPackets += record.FwdPackets[pos]
+		sumDropBytes += record.DropBytes[pos]
+		sumDropPackets += record.DropPackets[pos]
+	}
+	sumFwdBps := float64(sumFwdBytes*8) / float64(buckets*bucketDuration)
+	sumFwdPps := float64(sumFwdPackets) / float64(buckets*bucketDuration)
+	sumDropBps := float64(sumDropBytes*8) / float64(buckets*bucketDuration)
+	sumDropPps := float64(sumDropPackets) / float64(buckets*bucketDuration)
+	return sumFwdBps, sumFwdPps, sumDropBps, sumDropPps
+}
+
+func (record *Record) tick(thresholdBuckets int, bucketDuration int, thresholdBps uint64, thresholdPps uint64) {
+	record.Lock()
+	defer record.Unlock()
+	// advance pointer to the next position
+	record.pointer++
+	if record.pointer >= record.capacity {
+		record.pointer = 0
+	}
+	// calculate averages and check thresholds
+	if thresholdBuckets == 0 {
+		// thresholdBuckets == 0 means "look at the whole window"
+		thresholdBuckets = record.capacity
+	}
+	var sumBytes uint64
+	var sumPackets uint64
+	pos := record.pointer
+	for i := 0; i < thresholdBuckets; i++ {
+		if pos <= 0 {
+			pos = record.capacity - 1
+		} else {
+			pos--
+		}
+		sumBytes = sumBytes + record.FwdBytes[pos] + record.DropBytes[pos]
+		sumPackets = sumPackets + record.FwdPackets[pos] + record.DropPackets[pos]
+	}
+	bps := uint64(float64(sumBytes*8) / float64(bucketDuration*thresholdBuckets))
+	pps := uint64(float64(sumPackets) / float64(bucketDuration*thresholdBuckets))
+	if (bps > thresholdBps) && (pps > thresholdPps) {
+		record.aboveThreshold.Store(true)
+	} else {
+		record.aboveThreshold.Store(false)
+	}
+	// clear the current bucket
+	record.FwdBytes[record.pointer] = 0
+	record.FwdPackets[record.pointer] = 0
+	record.DropBytes[record.pointer] = 0
+	record.DropPackets[record.pointer] = 0
+}
+
+func (db *Database) Clock() {
+	ticker := time.NewTicker(time.Duration(db.bucketDuration) * time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			db.Lock()
+			for _, record := range *db.database {
+				record.tick(db.thresholdBuckets, db.bucketDuration, db.thresholdBps, db.thresholdPps)
+			}
+			db.Unlock()
+		case <-db.stopClockC:
+			return
+		}
+	}
+}
+
+func (db *Database) Cleanup() {
+	ticker := time.NewTicker(time.Duration(db.bucketDuration*db.buckets) * time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			db.Lock()
+			db.cleanupCounter--
+			if db.cleanupCounter <= 0 {
+				db.cleanupCounter = db.buckets * cleanupWindowSizes
+				for key, record := range *db.database {
+					if record.isEmpty() {
+						delete(*db.database, key)
+					}
+				}
+			}
+			db.promExporter.dbSize.Set(float64(len(*db.database)))
+			db.Unlock()
+		case <-db.stopCleanupC:
+			return
+		}
+	}
+}
+
+func (db *Database) StopTimers() {
+	var stopmessage struct{}
+	db.stopClockC <- stopmessage
+}
+
+func (db *Database) GetAllRecords() <-chan struct {
+	key    string
+	record *Record
+} {
+	out := make(chan struct {
+		key    string
+		record *Record
+	})
+	go func() {
+		db.Lock()
+		defer func() {
+			db.Unlock()
+			close(out)
+		}()
+		for key, record := range *db.database {
+			out <- struct {
+				key    string
+				record *Record
+			}{key, record}
+		}
+	}()
+	return out
+}

--- a/segments/analysis/toptalkers_metrics/toptalker_prometheus.go
+++ b/segments/analysis/toptalkers_metrics/toptalker_prometheus.go
@@ -1,0 +1,273 @@
+package toptalkers_metrics
+
+import (
+	"errors"
+	"log"
+	"net/http"
+	"strconv"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+type PrometheusCollector struct {
+	database       *Database
+	ReportBuckets  int
+	BucketDuration int
+	TrafficType    string
+	trafficBpsDesc *prometheus.Desc
+	trafficPpsDesc *prometheus.Desc
+}
+
+type PrometheusMetricsParams struct {
+	TrafficType      string `yaml:"traffictype,omitempty"`      // optional, default is "", name for the traffic type (included as label)
+	Buckets          int    `yaml:"buckets,omitempty"`          // optional, default is 60, sets the number of seconds used as a sliding window size
+	ThresholdBuckets int    `yaml:"thresholdbuckets,omitempty"` // optional, use the last N buckets for calculation of averages, default: $Buckets
+	ReportBuckets    int    `yaml:"reportbuckets,omitempty"`    // optional, use the last N buckets to calculate averages that are reported as result, default: $Buckets
+	BucketDuration   int    `yaml:"bucketduration,omitempty"`   // optional, duration of a bucket, default is 1 second
+	ThresholdBps     uint64 `yaml:"thresholdbps,omitempty"`     // optional, default is 0, only log talkers with an average bits per second rate higher than this value
+	ThresholdPps     uint64 `yaml:"thresholdpps,omitempty"`     // optional, default is 0, only log talkers with an average packets per second rate higher than this value
+	RelevantAddress  string `yaml:"relevantaddress,omitempty"`  // optional, default is "destination", options are "destination", "source", "both"
+}
+
+type PrometheusParams struct {
+	Endpoint     string // optional, default value is ":8080"
+	MetricsPath  string // optional, default is "/metrics"
+	FlowdataPath string // optional, default is "/flowdata"
+}
+
+func NewPrometheusCollector(database *Database, trafficType string, reportBuckets int) *PrometheusCollector {
+	coll := PrometheusCollector{
+		database:       database,
+		ReportBuckets:  reportBuckets,
+		BucketDuration: database.bucketDuration,
+		TrafficType:    trafficType,
+	}
+	coll.InitDescriptors()
+	return &coll
+}
+
+func (params *PrometheusParams) InitDefaultPrometheusParams() {
+	params.Endpoint = ":8080"
+	params.MetricsPath = "/metrics"
+	params.FlowdataPath = "/flowdata"
+}
+
+func (params *PrometheusMetricsParams) InitDefaultPrometheusMetricParams() {
+	if params.Buckets == 0 {
+		params.Buckets = 60
+	}
+	if params.ThresholdBuckets == 0 {
+		params.ThresholdBuckets = 60
+	}
+	if params.ReportBuckets == 0 {
+		params.ReportBuckets = 60
+	}
+	if params.BucketDuration == 0 {
+		params.BucketDuration = 1
+	}
+	if params.RelevantAddress == "" {
+		params.RelevantAddress = "destination"
+	}
+}
+
+func (prometheusParams *PrometheusMetricsParams) ParsePrometheusConfig(config map[string]string) error {
+	if config["buckets"] != "" {
+		if parsedBuckets, err := strconv.ParseInt(config["buckets"], 10, 64); err == nil {
+			prometheusParams.Buckets = int(parsedBuckets)
+			if prometheusParams.Buckets <= 0 {
+				return errors.New("[error] : Buckets has to be >0")
+			}
+		} else {
+			log.Println("[error] ToptalkersMetrics: Could not parse 'buckets' parameter, using default 60.")
+		}
+	} else {
+		log.Println("[info] ToptalkersMetrics: 'buckets' set to default 60.")
+	}
+
+	if config["thresholdbuckets"] != "" {
+		if parsedThresholdBuckets, err := strconv.ParseInt(config["thresholdbuckets"], 10, 64); err == nil {
+			prometheusParams.ThresholdBuckets = int(parsedThresholdBuckets)
+			if prometheusParams.ThresholdBuckets <= 0 {
+				return errors.New("[error] : thresholdbuckets has to be >0")
+			}
+		} else {
+			log.Println("[error] ToptalkersMetrics: Could not parse 'thresholdbuckets' parameter, using default (60 buckets).")
+		}
+	} else {
+		log.Println("[info] ToptalkersMetrics: 'thresholdbuckets' set to default (60 buckets).")
+	}
+
+	if config["reportbuckets"] != "" {
+		if parsedReportBuckets, err := strconv.ParseInt(config["reportbuckets"], 10, 64); err == nil {
+			prometheusParams.ReportBuckets = int(parsedReportBuckets)
+			if prometheusParams.ReportBuckets <= 0 {
+				return errors.New("[error] : reportbuckets has to be >0")
+			}
+		} else {
+			log.Println("[error] ReportPrometheus: Could not parse 'reportbuckets' parameter, using default (60 buckets).")
+		}
+	} else {
+		log.Println("[info] ReportPrometheus: 'reportbuckets' set to default (60 buckets).")
+	}
+
+	if config["traffictype"] != "" {
+		prometheusParams.TrafficType = config["traffictype"]
+	} else {
+		log.Println("[info] ToptalkersMetrics: 'traffictype' is empty.")
+	}
+
+	if config["thresholdbps"] != "" {
+		if parsedThresholdBps, err := strconv.ParseUint(config["thresholdbps"], 10, 32); err == nil {
+			prometheusParams.ThresholdBps = parsedThresholdBps
+		} else {
+			log.Println("[error] ToptalkersMetrics: Could not parse 'thresholdbps' parameter, using default 0.")
+		}
+	} else {
+		log.Println("[info] ToptalkersMetrics: 'thresholdbps' set to default '0'.")
+	}
+
+	if config["thresholdpps"] != "" {
+		if parsedThresholdPps, err := strconv.ParseUint(config["thresholdpps"], 10, 32); err == nil {
+			prometheusParams.ThresholdPps = parsedThresholdPps
+		} else {
+			log.Println("[error] ToptalkersMetrics: Could not parse 'thresholdpps' parameter, using default 0.")
+		}
+	} else {
+		log.Println("[info] ToptalkersMetrics: 'thresholdpps' set to default '0'.")
+	}
+
+	switch config["relevantaddress"] {
+	case
+		"destination",
+		"source",
+		"both":
+		prometheusParams.RelevantAddress = config["relevantaddress"]
+	case "":
+		log.Println("[info] ToptalkersMetrics: 'relevantaddress' set to default 'destination'.")
+	default:
+		log.Println("[error] ToptalkersMetrics: Could not parse 'relevantaddress', using default value 'destination'.")
+	}
+	return nil
+}
+
+func (c *PrometheusCollector) InitDescriptors() {
+	var (
+		bps_fqName string
+		pps_fqName string
+		bps_help   string
+		pps_help   string
+	)
+
+	if c.TrafficType != "" {
+		bps_fqName = c.TrafficType + "_traffic_bps"
+		pps_fqName = c.TrafficType + "_traffic_pps"
+		bps_help = "Traffic volume in bits per second of traffic type " + c.TrafficType + ", for a given address"
+		pps_help = "Traffic in packets per second of traffic type " + c.TrafficType + ", for a given address."
+	} else {
+		bps_fqName = "traffic_bps"
+		pps_fqName = "traffic_pps"
+		bps_help = "Traffic volume in bits per second, for a given address"
+		pps_help = "Traffic in packets per second, for a given address."
+	}
+
+	c.trafficBpsDesc = prometheus.NewDesc(
+		bps_fqName,
+		bps_help,
+		[]string{"traffic_type", "address", "forwarding_status"}, nil,
+	)
+	c.trafficPpsDesc = prometheus.NewDesc(
+		pps_fqName,
+		pps_help,
+		[]string{"traffic_type", "address", "forwarding_status"}, nil,
+	)
+}
+
+func (c *PrometheusCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- c.trafficBpsDesc
+	ch <- c.trafficPpsDesc
+}
+func (collector *PrometheusCollector) Collect(ch chan<- prometheus.Metric) {
+	for entry := range collector.database.GetAllRecords() {
+		key := entry.key
+		record := entry.record
+		// check if thresholds are exceeded
+		buckets := collector.ReportBuckets
+		bucketDuration := collector.BucketDuration
+		if record.aboveThreshold.Load() {
+			sumFwdBps, sumFwdPps, sumDropBps, sumDropPps := record.GetMetrics(buckets, bucketDuration)
+			ch <- prometheus.MustNewConstMetric(
+				collector.trafficBpsDesc,
+				prometheus.GaugeValue,
+				sumFwdBps,
+				collector.TrafficType, key, "forwarded",
+			)
+			ch <- prometheus.MustNewConstMetric(
+				collector.trafficBpsDesc,
+				prometheus.GaugeValue,
+				sumDropBps,
+				collector.TrafficType, key, "dropped",
+			)
+			ch <- prometheus.MustNewConstMetric(
+				collector.trafficPpsDesc,
+				prometheus.GaugeValue,
+				sumFwdPps,
+				collector.TrafficType, key, "forwarded",
+			)
+			ch <- prometheus.MustNewConstMetric(
+				collector.trafficPpsDesc,
+				prometheus.GaugeValue,
+				sumDropPps,
+				collector.TrafficType, key, "dropped",
+			)
+		}
+	}
+}
+
+// Exporter provides export features to Prometheus
+type PrometheusExporter struct {
+	MetaReg *prometheus.Registry
+	FlowReg *prometheus.Registry
+
+	KafkaMessageCount prometheus.Counter
+	dbSize            prometheus.Gauge
+}
+
+// Initialize Prometheus Exporter
+func (e *PrometheusExporter) Initialize() {
+	e.KafkaMessageCount = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "kafka_messages_total",
+			Help: "Number of Kafka messages",
+		})
+	e.dbSize = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "toptalkers_db_size",
+			Help: "Number of Keys in the current toptalkers database",
+		})
+	e.MetaReg = prometheus.NewRegistry()
+	e.FlowReg = prometheus.NewRegistry()
+	e.MetaReg.MustRegister(e.KafkaMessageCount)
+	e.MetaReg.MustRegister(e.dbSize)
+}
+
+// listen on given endpoint addr with Handler for metricPath and flowdataPath
+func (e *PrometheusExporter) ServeEndpoints(promParams *PrometheusParams) {
+	mux := http.NewServeMux()
+	mux.Handle(promParams.MetricsPath, promhttp.HandlerFor(e.MetaReg, promhttp.HandlerOpts{}))
+	mux.Handle(promParams.FlowdataPath, promhttp.HandlerFor(e.FlowReg, promhttp.HandlerOpts{}))
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`<html>
+			<head><title>Flow Exporter</title></head>
+			<body>
+			<h1>Flow Exporter</h1>
+			<p><a href="` + promParams.MetricsPath + `">Metrics</p>
+			<p><a href="` + promParams.FlowdataPath + `">Flow Data</p>
+			</body>
+		</html>`))
+	})
+	go func() {
+		http.ListenAndServe(promParams.Endpoint, mux)
+	}()
+	log.Printf("Enabled metrics on %s and %s, listening at %s.", promParams.MetricsPath, promParams.FlowdataPath, promParams.Endpoint)
+}

--- a/segments/analysis/toptalkers_metrics/toptalkers_metrics.go
+++ b/segments/analysis/toptalkers_metrics/toptalkers_metrics.go
@@ -7,8 +7,6 @@ import (
 	"github.com/BelWue/flowpipeline/segments"
 )
 
-const cleanupWindowSizes = 5
-
 type ToptalkersMetrics struct {
 	segments.BaseFilterSegment
 	PrometheusMetricsParams
@@ -52,8 +50,8 @@ func (segment *ToptalkersMetrics) Run(wg *sync.WaitGroup) {
 
 	var promExporter = PrometheusExporter{}
 
-	database := NewDatabase(segment.ThresholdBps, segment.ThresholdPps, segment.Buckets, segment.BucketDuration, segment.ThresholdBuckets, cleanupWindowSizes, &promExporter)
-	collector := NewPrometheusCollector(&database, segment.TrafficType, segment.ReportBuckets)
+	database := NewDatabase(segment.PrometheusMetricsParams, &promExporter)
+	collector := NewPrometheusCollector([]*Database{&database})
 	promExporter.Initialize()
 	promExporter.FlowReg.MustRegister(collector)
 	promExporter.ServeEndpoints(&segment.PrometheusParams)

--- a/segments/analysis/toptalkers_metrics/toptalkers_metrics.go
+++ b/segments/analysis/toptalkers_metrics/toptalkers_metrics.go
@@ -1,377 +1,30 @@
-package flowpipeline
+package toptalkers_metrics
 
 import (
-	"bufio"
 	"log"
-	"net/http"
-	"strconv"
 	"sync"
-	"sync/atomic"
-	"time"
 
 	"github.com/BelWue/flowpipeline/segments"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 const cleanupWindowSizes = 5
 
-type Record struct {
-	FwdBytes       []uint64
-	FwdPackets     []uint64
-	DropBytes      []uint64
-	DropPackets    []uint64
-	capacity       int
-	pointer        int
-	aboveThreshold atomic.Bool
-	sync.RWMutex
-}
-
 type ToptalkersMetrics struct {
 	segments.BaseFilterSegment
-	writer   *bufio.Writer
-	database *Database
-
-	TrafficType      string // optional, default is "", name for the traffic type (included as label)
-	Buckets          int    // optional, default is 60, sets the number of seconds used as a sliding window size
-	ThresholdBuckets int    // optional, use the last N buckets for calculation of averages, default: $Buckets
-	ReportBuckets    int    // optional, use the last N buckets to calculate averages that are reported as result, default: $Buckets
-	BucketDuration   int    // optional, duration of a bucket, default is 1 second
-	ThresholdBps     uint64 // optional, default is 0, only log talkers with an average bits per second rate higher than this value
-	ThresholdPps     uint64 // optional, default is 0, only log talkers with an average packets per second rate higher than this value
-	Endpoint         string // optional, default value is ":8080"
-	MetricsPath      string // optional, default is "/metrics"
-	FlowdataPath     string // optional, default is "/flowdata"
-	RelevantAddress  string // optional, default is "destination", options are "destination", "source", "both"
-}
-
-type Database struct {
-	database         map[string]*Record
-	thresholdBps     uint64
-	thresholdPps     uint64
-	buckets          int // seconds
-	bucketDuration   int // seconds
-	thresholdBuckets int
-	cleanupCounter   int
-	promExporter     PrometheusExporter
-	stopOnce         sync.Once
-	stopCleanupC     chan struct{}
-	stopClockC       chan struct{}
-	sync.RWMutex
-}
-
-func (db *Database) GetRecord(key string) *Record {
-	db.Lock()
-	defer db.Unlock()
-	record, found := db.database[key]
-	if !found || record == nil {
-		record = NewRecord(db.buckets)
-		db.database[key] = record
-	}
-	return record
-}
-
-func NewRecord(windowSize int) *Record {
-	record := &Record{
-		FwdBytes:    make([]uint64, windowSize),
-		FwdPackets:  make([]uint64, windowSize),
-		DropBytes:   make([]uint64, windowSize),
-		DropPackets: make([]uint64, windowSize),
-		capacity:    windowSize,
-		pointer:     0,
-	}
-	return record
-}
-
-func (record *Record) Append(bytes uint64, packets uint64, statusFwd bool) {
-	record.Lock()
-	defer record.Unlock()
-	if statusFwd == true {
-		record.FwdBytes[record.pointer] += bytes
-		record.FwdPackets[record.pointer] += packets
-	} else {
-		record.DropBytes[record.pointer] += bytes
-		record.DropPackets[record.pointer] += packets
-	}
-}
-
-func (record *Record) isEmpty() bool {
-	record.RLock()
-	defer record.RUnlock()
-	for i := 0; i < record.capacity; i++ {
-		if record.FwdPackets[i] > 0 || record.DropPackets[i] > 0 {
-			return false
-		}
-	}
-	return true
-}
-
-func (record *Record) GetMetrics(buckets int, bucketDuration int) (float64, float64, float64, float64) {
-	// buckets == 0 means "look at the whole window"
-	if buckets == 0 {
-		buckets = record.capacity
-	}
-	sumFwdBytes := uint64(0)
-	sumFwdPackets := uint64(0)
-	sumDropBytes := uint64(0)
-	sumDropPackets := uint64(0)
-	record.RLock()
-	defer record.RUnlock()
-	pos := record.pointer
-	for i := 0; i < buckets; i++ {
-		if pos <= 0 {
-			pos = record.capacity - 1
-		} else {
-			pos--
-		}
-		sumFwdBytes += record.FwdBytes[pos]
-		sumFwdPackets += record.FwdPackets[pos]
-		sumDropBytes += record.DropBytes[pos]
-		sumDropPackets += record.DropPackets[pos]
-	}
-	sumFwdBps := float64(sumFwdBytes*8) / float64(buckets*bucketDuration)
-	sumFwdPps := float64(sumFwdPackets) / float64(buckets*bucketDuration)
-	sumDropBps := float64(sumDropBytes*8) / float64(buckets*bucketDuration)
-	sumDropPps := float64(sumDropPackets) / float64(buckets*bucketDuration)
-	return sumFwdBps, sumFwdPps, sumDropBps, sumDropPps
-}
-
-func (record *Record) tick(thresholdBuckets int, bucketDuration int, thresholdBps uint64, thresholdPps uint64) {
-	record.Lock()
-	defer record.Unlock()
-	// advance pointer to the next position
-	record.pointer++
-	if record.pointer >= record.capacity {
-		record.pointer = 0
-	}
-	// calculate averages and check thresholds
-	if thresholdBuckets == 0 {
-		// thresholdBuckets == 0 means "look at the whole window"
-		thresholdBuckets = record.capacity
-	}
-	var sumBytes uint64
-	var sumPackets uint64
-	pos := record.pointer
-	for i := 0; i < thresholdBuckets; i++ {
-		if pos <= 0 {
-			pos = record.capacity - 1
-		} else {
-			pos--
-		}
-		sumBytes = sumBytes + record.FwdBytes[pos] + record.DropBytes[pos]
-		sumPackets = sumPackets + record.FwdPackets[pos] + record.DropPackets[pos]
-	}
-	bps := uint64(float64(sumBytes*8) / float64(bucketDuration*thresholdBuckets))
-	pps := uint64(float64(sumPackets) / float64(bucketDuration*thresholdBuckets))
-	if (bps > thresholdBps) && (pps > thresholdPps) {
-		record.aboveThreshold.Store(true)
-	} else {
-		record.aboveThreshold.Store(false)
-	}
-	// clear the current bucket
-	record.FwdBytes[record.pointer] = 0
-	record.FwdPackets[record.pointer] = 0
-	record.DropBytes[record.pointer] = 0
-	record.DropPackets[record.pointer] = 0
-}
-
-func (db *Database) clock() {
-	ticker := time.NewTicker(time.Duration(db.bucketDuration) * time.Second)
-	defer ticker.Stop()
-	for {
-		select {
-		case <-ticker.C:
-			db.Lock()
-			for _, record := range db.database {
-				record.tick(db.thresholdBuckets, db.bucketDuration, db.thresholdBps, db.thresholdPps)
-			}
-			db.Unlock()
-		case <-db.stopClockC:
-			return
-		}
-	}
-}
-
-func (db *Database) cleanup() {
-	ticker := time.NewTicker(time.Duration(db.bucketDuration*db.buckets) * time.Second)
-	defer ticker.Stop()
-	for {
-		select {
-		case <-ticker.C:
-			db.Lock()
-			db.cleanupCounter--
-			if db.cleanupCounter <= 0 {
-				db.cleanupCounter = db.buckets * cleanupWindowSizes
-				for key, record := range db.database {
-					if record.isEmpty() == true {
-						delete(db.database, key)
-					}
-				}
-			}
-			db.promExporter.dbSize.Set(float64(len(db.database)))
-			db.Unlock()
-		case <-db.stopCleanupC:
-			return
-		}
-	}
-}
-
-func (db *Database) GetAllRecords() <-chan struct {
-	key    string
-	record *Record
-} {
-	out := make(chan struct {
-		key    string
-		record *Record
-	})
-	go func() {
-		db.Lock()
-		defer func() {
-			db.Unlock()
-			close(out)
-		}()
-		for key, record := range db.database {
-			out <- struct {
-				key    string
-				record *Record
-			}{key, record}
-		}
-	}()
-	return out
-}
-
-// Exporter provides export features to Prometheus
-type PrometheusExporter struct {
-	MetaReg *prometheus.Registry
-	FlowReg *prometheus.Registry
-
-	kafkaMessageCount prometheus.Counter
-	dbSize            prometheus.Gauge
-}
-
-// Initialize Prometheus Exporter
-func (e *PrometheusExporter) Initialize(collector *PrometheusCollector) {
-	// The Kafka metrics are added to the global registry.
-	e.kafkaMessageCount = prometheus.NewCounter(
-		prometheus.CounterOpts{
-			Name: "kafka_messages_total",
-			Help: "Number of Kafka messages",
-		})
-	e.dbSize = prometheus.NewGauge(
-		prometheus.GaugeOpts{
-			Name: "toptalkers_db_size",
-			Help: "Number of Keys in the current toptalkers database",
-		})
-	e.MetaReg = prometheus.NewRegistry()
-	e.MetaReg.MustRegister(e.kafkaMessageCount)
-	e.MetaReg.MustRegister(e.dbSize)
-
-	e.FlowReg = prometheus.NewRegistry()
-	e.FlowReg.MustRegister(collector)
-}
-
-// listen on given endpoint addr with Handler for metricPath and flowdataPath
-func (e *PrometheusExporter) ServeEndpoints(segment *ToptalkersMetrics) {
-	mux := http.NewServeMux()
-	mux.Handle(segment.MetricsPath, promhttp.HandlerFor(e.MetaReg, promhttp.HandlerOpts{}))
-	mux.Handle(segment.FlowdataPath, promhttp.HandlerFor(e.FlowReg, promhttp.HandlerOpts{}))
-	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte(`<html>
-			<head><title>Flow Exporter</title></head>
-			<body>
-			<h1>Flow Exporter</h1>
-			<p><a href="` + segment.MetricsPath + `">Metrics</p>
-			<p><a href="` + segment.FlowdataPath + `">Flow Data</p>
-			</body>
-		</html>`))
-	})
-	go func() {
-		http.ListenAndServe(segment.Endpoint, mux)
-	}()
-	log.Printf("Enabled metrics on %s and %s, listening at %s.", segment.MetricsPath, segment.FlowdataPath, segment.Endpoint)
+	PrometheusMetricsParams
+	PrometheusParams
 }
 
 func (segment ToptalkersMetrics) New(config map[string]string) segments.Segment {
-	newsegment := &ToptalkersMetrics{
-		Buckets:          60,
-		ThresholdBuckets: 60,
-		ReportBuckets:    60,
-		BucketDuration:   1,
-		TrafficType:      "",
-		Endpoint:         ":8080",
-		MetricsPath:      "/metrics",
-		FlowdataPath:     "/flowdata",
-		RelevantAddress:  "destination",
-	}
+	newsegment := &ToptalkersMetrics{}
+	newsegment.InitDefaultPrometheusParams()
+	newsegment.InitDefaultPrometheusMetricParams()
 
-	if config["buckets"] != "" {
-		if parsedBuckets, err := strconv.ParseInt(config["buckets"], 10, 64); err == nil {
-			newsegment.Buckets = int(parsedBuckets)
-			if newsegment.Buckets <= 0 {
-				log.Println("[error] : Buckets has to be >0.")
-				return nil
-			}
-		} else {
-			log.Println("[error] ToptalkersMetrics: Could not parse 'buckets' parameter, using default 60.")
-		}
-	} else {
-		log.Println("[info] ToptalkersMetrics: 'buckets' set to default 60.")
+	err := newsegment.ParsePrometheusConfig(config)
+	if err != nil {
+		log.Println(err.Error())
+		return nil
 	}
-
-	if config["thresholdbuckets"] != "" {
-		if parsedThresholdBuckets, err := strconv.ParseInt(config["thresholdbuckets"], 10, 64); err == nil {
-			newsegment.ThresholdBuckets = int(parsedThresholdBuckets)
-			if newsegment.ThresholdBuckets <= 0 {
-				log.Println("[error] : thresholdbuckets has to be >0.")
-				return nil
-			}
-		} else {
-			log.Println("[error] ToptalkersMetrics: Could not parse 'thresholdbuckets' parameter, using default (60 buckets).")
-		}
-	} else {
-		log.Println("[info] ToptalkersMetrics: 'thresholdbuckets' set to default (60 buckets).")
-	}
-
-	if config["reportbuckets"] != "" {
-		if parsedReportBuckets, err := strconv.ParseInt(config["reportbuckets"], 10, 64); err == nil {
-			newsegment.ReportBuckets = int(parsedReportBuckets)
-			if newsegment.ReportBuckets <= 0 {
-				log.Println("[error] : reportbuckets has to be >0.")
-				return nil
-			}
-		} else {
-			log.Println("[error] ReportPrometheus: Could not parse 'reportbuckets' parameter, using default (60 buckets).")
-		}
-	} else {
-		log.Println("[info] ReportPrometheus: 'reportbuckets' set to default (60 buckets).")
-	}
-
-	if config["traffictype"] != "" {
-		newsegment.TrafficType = config["traffictype"]
-	} else {
-		log.Println("[info] ToptalkersMetrics: 'traffictype' is empty.")
-	}
-
-	if config["thresholdbps"] != "" {
-		if parsedThresholdBps, err := strconv.ParseUint(config["thresholdbps"], 10, 32); err == nil {
-			newsegment.ThresholdBps = parsedThresholdBps
-		} else {
-			log.Println("[error] ToptalkersMetrics: Could not parse 'thresholdbps' parameter, using default 0.")
-		}
-	} else {
-		log.Println("[info] ToptalkersMetrics: 'thresholdbps' set to default '0'.")
-	}
-
-	if config["thresholdpps"] != "" {
-		if parsedThresholdPps, err := strconv.ParseUint(config["thresholdpps"], 10, 32); err == nil {
-			newsegment.ThresholdPps = parsedThresholdPps
-		} else {
-			log.Println("[error] ToptalkersMetrics: Could not parse 'thresholdpps' parameter, using default 0.")
-		}
-	} else {
-		log.Println("[info] ToptalkersMetrics: 'thresholdpps' set to default '0'.")
-	}
-
 	if config["endpoint"] == "" {
 		log.Println("[info] ToptalkersMetrics Missing configuration parameter 'endpoint'. Using default port \":8080\"")
 	} else {
@@ -381,24 +34,12 @@ func (segment ToptalkersMetrics) New(config map[string]string) segments.Segment 
 	if config["metricspath"] == "" {
 		log.Println("[info] ToptalkersMetrics: Missing configuration parameter 'metricspath'. Using default path \"/metrics\"")
 	} else {
-		newsegment.FlowdataPath = config["metricspath"]
+		newsegment.MetricsPath = config["metricspath"]
 	}
 	if config["flowdatapath"] == "" {
 		log.Println("[info] ThresholdToptalkersMetrics: Missing configuration parameter 'flowdatapath'. Using default path \"/flowdata\"")
 	} else {
 		newsegment.FlowdataPath = config["flowdatapath"]
-	}
-
-	switch config["relevantaddress"] {
-	case
-		"destination",
-		"source",
-		"both":
-		newsegment.RelevantAddress = config["relevantaddress"]
-	case "":
-		log.Println("[info] ToptalkersMetrics: 'relevantaddress' set to default 'destination'.")
-	default:
-		log.Println("[error] ToptalkersMetrics: Could not parse 'relevantaddress', using default value 'destination'.")
 	}
 	return newsegment
 }
@@ -410,27 +51,18 @@ func (segment *ToptalkersMetrics) Run(wg *sync.WaitGroup) {
 	}()
 
 	var promExporter = PrometheusExporter{}
-	collector := &PrometheusCollector{segment}
-	promExporter.Initialize(collector)
-	promExporter.ServeEndpoints(segment)
 
-	segment.database = &Database{
-		database:         map[string]*Record{},
-		thresholdBps:     segment.ThresholdBps,
-		thresholdPps:     segment.ThresholdPps,
-		thresholdBuckets: segment.ThresholdBuckets,
-		cleanupCounter:   segment.Buckets * cleanupWindowSizes, // cleanup every N windows
-		promExporter:     promExporter,
-		buckets:          segment.Buckets,
-		bucketDuration:   segment.BucketDuration,
-		stopCleanupC:     make(chan struct{}),
-		stopClockC:       make(chan struct{}),
-	}
-	go segment.database.clock()
-	go segment.database.cleanup()
+	database := NewDatabase(segment.ThresholdBps, segment.ThresholdPps, segment.Buckets, segment.BucketDuration, segment.ThresholdBuckets, cleanupWindowSizes, &promExporter)
+	collector := NewPrometheusCollector(&database, segment.TrafficType, segment.ReportBuckets)
+	promExporter.Initialize()
+	promExporter.FlowReg.MustRegister(collector)
+	promExporter.ServeEndpoints(&segment.PrometheusParams)
+
+	go database.Clock()
+	go database.Cleanup()
 
 	for msg := range segment.In {
-		promExporter.kafkaMessageCount.Inc()
+		promExporter.KafkaMessageCount.Inc()
 		var keys []string
 		if segment.RelevantAddress == "source" {
 			keys = []string{msg.SrcAddrObj().String()}
@@ -441,74 +73,16 @@ func (segment *ToptalkersMetrics) Run(wg *sync.WaitGroup) {
 		}
 		forward := false
 		for _, key := range keys {
-			record := segment.database.GetRecord(key)
+			record := database.GetRecord(key)
 			record.Append(msg.Bytes, msg.Packets, msg.IsForwarded())
-			if record.aboveThreshold.Load() == true {
+			if record.aboveThreshold.Load() {
 				forward = true
 			}
 		}
-		if forward == true {
+		if forward {
 			segment.Out <- msg
 		} else if segment.Drops != nil {
 			segment.Drops <- msg
-		}
-	}
-}
-
-var (
-	trafficBpsDesc = prometheus.NewDesc(
-		"traffic_bps",
-		"Traffic volume in bits per second for a given address.",
-		[]string{"traffic_type", "address", "forwarding_status"}, nil,
-	)
-	trafficPpsDesc = prometheus.NewDesc(
-		"traffic_pps",
-		"Traffic in packets per second for a given address.",
-		[]string{"traffic_type", "address", "forwarding_status"}, nil,
-	)
-)
-
-type PrometheusCollector struct {
-	segment *ToptalkersMetrics
-}
-
-func (collector *PrometheusCollector) Describe(ch chan<- *prometheus.Desc) {
-	ch <- trafficBpsDesc
-	ch <- trafficPpsDesc
-}
-func (collector *PrometheusCollector) Collect(ch chan<- prometheus.Metric) {
-	for entry := range collector.segment.database.GetAllRecords() {
-		key := entry.key
-		record := entry.record
-		// check if thresholds are exceeded
-		buckets := collector.segment.ReportBuckets
-		bucketDuration := collector.segment.BucketDuration
-		if record.aboveThreshold.Load() == true {
-			sumFwdBps, sumFwdPps, sumDropBps, sumDropPps := record.GetMetrics(buckets, bucketDuration)
-			ch <- prometheus.MustNewConstMetric(
-				trafficBpsDesc,
-				prometheus.GaugeValue,
-				sumFwdBps,
-				collector.segment.TrafficType, key, "forwarded",
-			)
-			ch <- prometheus.MustNewConstMetric(
-				trafficBpsDesc,
-				prometheus.GaugeValue,
-				sumDropBps,
-				collector.segment.TrafficType, key, "dropped",
-			)
-			ch <- prometheus.MustNewConstMetric(
-				trafficPpsDesc,
-				prometheus.GaugeValue,
-				sumFwdPps,
-				collector.segment.TrafficType, key, "forwarded",
-			)
-			ch <- prometheus.MustNewConstMetric(
-				trafficPpsDesc,
-				prometheus.GaugeValue,
-				sumDropPps,
-				collector.segment.TrafficType, key, "dropped",
-			)
 		}
 	}
 }

--- a/segments/analysis/traffic_specific_toptalkers/traffic-specific-toptalkers.go
+++ b/segments/analysis/traffic_specific_toptalkers/traffic-specific-toptalkers.go
@@ -1,0 +1,170 @@
+// This segment is used to alert on flows reaching a specified threshold
+package traffic_specific_toptalkers
+
+import (
+	"log"
+	"sync"
+
+	"github.com/BelWue/flowfilter/parser"
+	"github.com/BelWue/flowpipeline/pb"
+	"github.com/BelWue/flowpipeline/segments"
+	"github.com/BelWue/flowpipeline/segments/analysis/toptalkers_metrics"
+	"github.com/BelWue/flowpipeline/segments/filter/flowfilter"
+)
+
+const cleanupWindowSizes = 5
+
+type TrafficSpecificToptalkers struct {
+	segments.BaseFilterSegment
+	toptalkers_metrics.PrometheusParams
+	ThresholdMetricDefinition []*ThresholdMetricDefinition
+}
+
+type ThresholdMetricDefinition struct {
+	toptalkers_metrics.PrometheusMetricsParams `yaml:",inline"`
+
+	Expression       *parser.Expression
+	FilterDefinition string                       `yaml:"filter,omitempty"`
+	SubDefinitions   []*ThresholdMetricDefinition `yaml:"metricdefinitions,omitempty"`
+	Database         *toptalkers_metrics.Database
+}
+
+func (segment TrafficSpecificToptalkers) New(config map[string]string) segments.Segment {
+	newSegment := &TrafficSpecificToptalkers{}
+	newSegment.InitDefaultPrometheusParams()
+	if config["endpoint"] == "" {
+		log.Println("[info] ToptalkersMetrics Missing configuration parameter 'endpoint'. Using default port \":8080\"")
+	} else {
+		newSegment.Endpoint = config["endpoint"]
+	}
+
+	if config["metricspath"] == "" {
+		log.Println("[info] ToptalkersMetrics: Missing configuration parameter 'metricspath'. Using default path \"/metrics\"")
+	} else {
+		newSegment.FlowdataPath = config["metricspath"]
+	}
+	if config["flowdatapath"] == "" {
+		log.Println("[info] ThresholdToptalkersMetrics: Missing configuration parameter 'flowdatapath'. Using default path \"/flowdata\"")
+	} else {
+		newSegment.FlowdataPath = config["flowdatapath"]
+	}
+
+	return newSegment
+}
+
+func (segment *TrafficSpecificToptalkers) SetThresholdMetricDefinition(definition []*ThresholdMetricDefinition) {
+	segment.ThresholdMetricDefinition = definition
+	for _, definition := range segment.ThresholdMetricDefinition {
+		err := initThresholdMetrics(definition)
+		if err != nil {
+			log.Println(err.Error())
+		}
+	}
+}
+
+func initThresholdMetrics(definition *ThresholdMetricDefinition) error {
+	definition.InitDefaultPrometheusMetricParams()
+	var err error
+	definition.Expression, err = parser.Parse(definition.FilterDefinition)
+	if err != nil {
+		log.Printf("[error] FlowFilter: Syntax error in filter expression: %v", err)
+		return nil
+	}
+	for _, subDefinition := range definition.SubDefinitions {
+		err := initThresholdMetrics(subDefinition)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (segment *TrafficSpecificToptalkers) Run(wg *sync.WaitGroup) {
+	var allDatabases *[]*toptalkers_metrics.Database
+	defer func() {
+		close(segment.Out)
+		for _, db := range *allDatabases {
+			db.StopTimers()
+		}
+		wg.Done()
+	}()
+
+	var promExporter = toptalkers_metrics.PrometheusExporter{}
+	promExporter.Initialize()
+
+	allDatabases = initDatabasesAndCollectors(promExporter, segment)
+
+	//start timers
+	promExporter.ServeEndpoints(&segment.PrometheusParams)
+	for _, db := range *allDatabases {
+		go db.Clock()
+		go db.Cleanup()
+	}
+
+	filter := &flowfilter.Filter{}
+	for msg := range segment.In {
+		promExporter.KafkaMessageCount.Inc()
+		for _, filterDef := range segment.ThresholdMetricDefinition {
+			addMessageToMatchingToptalkers(msg, filterDef, filter)
+		}
+		segment.Out <- msg
+	}
+	log.Printf("[info] Threshold Metric Report runing on " + segment.Endpoint)
+}
+
+func initDatabasesAndCollectors(promExporter toptalkers_metrics.PrometheusExporter, segment *TrafficSpecificToptalkers) *[]*toptalkers_metrics.Database {
+	allDatabases := []*toptalkers_metrics.Database{}
+	for _, filterDef := range segment.ThresholdMetricDefinition {
+		databases := initCollectors(filterDef, &promExporter)
+		allDatabases = append(allDatabases, databases...)
+	}
+	return &allDatabases
+}
+
+func initCollectors(filterDef *ThresholdMetricDefinition, promExporter *toptalkers_metrics.PrometheusExporter) []*toptalkers_metrics.Database {
+	databases := []*toptalkers_metrics.Database{}
+	if filterDef.TrafficType != "" { //defined a metric that should be in prometheus
+		database := toptalkers_metrics.NewDatabase(
+			filterDef.ThresholdBps, filterDef.ThresholdPps, filterDef.Buckets, filterDef.BucketDuration,
+			filterDef.ThresholdBuckets, cleanupWindowSizes, promExporter,
+		)
+		collector := toptalkers_metrics.NewPrometheusCollector(&database, filterDef.TrafficType, filterDef.ReportBuckets)
+		promExporter.FlowReg.MustRegister(collector)
+		filterDef.Database = &database
+		databases = append(databases, &database)
+	}
+	for _, subDef := range filterDef.SubDefinitions {
+		databases = append(databases, initCollectors(subDef, promExporter)...)
+	}
+	return databases
+}
+
+func addMessageToMatchingToptalkers(msg *pb.EnrichedFlow, definition *ThresholdMetricDefinition, filter *flowfilter.Filter) {
+	if match, _ := filter.CheckFlow(definition.Expression, msg); match {
+		// Update Counters if definition has a prometheus label defined
+		if definition.TrafficType != "" {
+			var keys []string
+			if definition.RelevantAddress == "source" {
+				keys = []string{msg.SrcAddrObj().String()}
+			} else if definition.RelevantAddress == "destination" {
+				keys = []string{msg.DstAddrObj().String()}
+			} else if definition.RelevantAddress == "both" {
+				keys = []string{msg.SrcAddrObj().String(), msg.DstAddrObj().String()}
+			}
+			for _, key := range keys {
+				record := definition.Database.GetRecord(key)
+				record.Append(msg.Bytes, msg.Packets, msg.IsForwarded())
+			}
+		}
+
+		//also check subfilters
+		for _, subdefinition := range definition.SubDefinitions {
+			addMessageToMatchingToptalkers(msg, subdefinition, filter)
+		}
+	}
+}
+
+func init() {
+	segment := &TrafficSpecificToptalkers{}
+	segments.RegisterSegment("traffic_specific_toptalkers", segment)
+}

--- a/segments/analysis/traffic_specific_toptalkers/traffic-specific-toptalkers_test.go
+++ b/segments/analysis/traffic_specific_toptalkers/traffic-specific-toptalkers_test.go
@@ -1,0 +1,61 @@
+package traffic_specific_toptalkers
+
+import (
+	"log"
+	"sync"
+	"testing"
+
+	"github.com/BelWue/flowpipeline/pb"
+	"github.com/BelWue/flowpipeline/segments"
+	"github.com/BelWue/flowpipeline/segments/analysis/toptalkers_metrics"
+)
+
+func TestSegment_Branch_passthrough(t *testing.T) {
+	msg := &pb.EnrichedFlow{SrcAddr: []byte{192, 168, 88, 142}, DstAddr: []byte{192, 168, 88, 123}, DstPort: 123, Packets: 1000, Bytes: 230000, Proto: 17} //Ntp (udp)
+	msg2 := &pb.EnrichedFlow{SrcAddr: []byte{192, 168, 88, 142}, DstAddr: []byte{192, 168, 88, 123}, DstPort: 443, Packets: 1, Bytes: 100, Proto: 6}
+
+	segment := segments.LookupSegment("traffic_specific_toptalkers")
+	//normally done via config
+	segment.(*TrafficSpecificToptalkers).ThresholdMetricDefinition = []*ThresholdMetricDefinition{
+		{
+			FilterDefinition: "proto udp",
+			SubDefinitions: []*ThresholdMetricDefinition{
+				{
+					FilterDefinition: "port 123",
+					PrometheusMetricsParams: toptalkers_metrics.PrometheusMetricsParams{
+						TrafficType:  "NTP",
+						ThresholdBps: 1,
+					},
+				},
+			},
+		},
+	}
+
+	segment = segment.New(map[string]string{})
+
+	if segment == nil {
+		log.Fatalf("[error] Configured segment traffic_specific_toptalkers could not be initialized properly, see previous messages.")
+	}
+
+	in, out := make(chan *pb.EnrichedFlow), make(chan *pb.EnrichedFlow)
+	segment.Rewire(in, out)
+
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
+	go segment.Run(wg)
+
+	in <- msg
+	resultMsg := <-out
+	if resultMsg == nil {
+		t.Error("Segment traffic_specific_toptalkers is not passing through flows.")
+	}
+
+	in <- msg2
+	resultMsg2 := <-out
+	close(in)
+	wg.Wait()
+
+	if resultMsg2 == nil {
+		t.Error("Segment traffic_specific_toptalkers is not passing through flows.")
+	}
+}


### PR DESCRIPTION
New segment that allows publishing filter-based top talker on a single endpoint.

This requires a more complex configuration structure. This draft contains a solution for this by adding a definition field. 
This field is currently specific for this segment. It could be beneficial to generalize this field further, allowing it to be used by multiple segments.