### PR TITLE
New option "bypass-messages" for segment branch

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -140,6 +140,9 @@ branch, `then` and `else`, as well as after the flows passed from the `branch`
 segment into consecutive segments. Dropping flows behaves regularly in both
 branches, but note that flows can not be dropped within the `if` branch
 segments, as this is taken as a cue to move them into the `else` branch.
+The `bypass-messages` flag can be used to forward all incoming messages to the 
+next segment, regardles of them being droped or forwarded inside the `if` or `else` 
+branch.
 
 If any of these three lists of segments (or subpipelines) is empty, the
 `branch` segment will behave as if this subpipeline consisted of a single

--- a/segments/controlflow/branch/branch_test.go
+++ b/segments/controlflow/branch/branch_test.go
@@ -20,11 +20,79 @@ func TestSegment_Branch_passthrough(t *testing.T) {
 	if segment == nil {
 		log.Fatal("[error] Configured segment 'branch' could not be initialized properly, see previous messages.")
 	}
+	segment.condition = NewMockPipeline()
+	segment.then_branch = NewMockPipeline()
+	segment.else_branch = NewMockPipeline()
+
 	in, out := make(chan *pb.EnrichedFlow), make(chan *pb.EnrichedFlow)
 	segment.Rewire(in, out)
 
 	wg := &sync.WaitGroup{}
 	wg.Add(1)
-	// this would timeout if it worked properly, instead it logs an error and returns
-	segment.Run(wg)
+	go segment.Run(wg)
+	in <- &pb.EnrichedFlow{}
+	result := <-segment.else_branch.GetDrop() //condition drops --> else branch --> drops
+	if result == nil {
+		t.Error("Segment Goflow is not dropping flows as expected.")
+	}
+}
+
+// If bypass is enabled, that branch forwards every incoming message regardless of the internal segments
+func TestSegment_Branch_passthrough_bypass(t *testing.T) {
+	segment := segments.LookupSegment("branch").New(map[string]string{"bypass-messages": "true"}).(*Branch)
+	if segment == nil {
+		log.Fatal("[error] Configured segment 'branch' could not be initialized properly, see previous messages.")
+	}
+	segment.condition = NewMockPipeline()
+	segment.then_branch = NewMockPipeline()
+	segment.else_branch = NewMockPipeline()
+
+	in, out := make(chan *pb.EnrichedFlow), make(chan *pb.EnrichedFlow)
+	segment.Rewire(in, out)
+
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
+	go segment.Run(wg)
+	in <- &pb.EnrichedFlow{}
+	result := <-out
+	if result == nil {
+		t.Error("Segment Goflow is not passing through flows.")
+	}
+	close(in)
+}
+
+func NewMockPipeline() Pipeline {
+	mock := &MockPipeline{}
+	mock.Drop = make(chan *pb.EnrichedFlow)
+	mock.In = make(chan *pb.EnrichedFlow)
+	mock.Out = make(chan *pb.EnrichedFlow)
+	return mock
+}
+
+// Mock implementation dropping every message
+type MockPipeline struct {
+	In   chan *pb.EnrichedFlow
+	Out  <-chan *pb.EnrichedFlow
+	Drop chan *pb.EnrichedFlow
+}
+
+func (m *MockPipeline) Start() {
+	for msg := range m.In { // connect our own input to conditional
+		m.Drop <- msg
+	}
+}
+func (m *MockPipeline) Close() {
+	defer func() {
+		recover() // in case In is already closed
+	}()
+	close(m.In)
+}
+func (m *MockPipeline) GetInput() chan *pb.EnrichedFlow {
+	return m.In
+}
+func (m *MockPipeline) GetOutput() <-chan *pb.EnrichedFlow {
+	return m.Out
+}
+func (m *MockPipeline) GetDrop() <-chan *pb.EnrichedFlow {
+	return m.Drop
 }


### PR DESCRIPTION
Allows using filters in branch message and still working with all messages in the next segment